### PR TITLE
Node 10.10.0

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,11 +2,15 @@ steps:
   # node 10.10.0
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker build --target base --build-arg=NODE_VERSION=10.10.0 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.10.0 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.x --build-arg=NPM_VERSION=6.4.0 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
+    args: ['-c', 'docker build --target base --build-arg=NODE_VERSION=10.10.0 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.10.0 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.x --build-arg=NPM_VERSION=6.4.1 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
     secretEnv: ['GITHUB_PAT']
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker build --target builder --build-arg=NODE_VERSION=10.10.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.10.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.x --build-arg=NPM_VERSION=6.4.0 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
+    args: ['-c', 'docker build --build-arg=NODE_VERSION=10.10.0 --tag=gcr.io/$PROJECT_ID/node-fat-base.$BRANCH_NAME:10.10.0 --tag=gcr.io/$PROJECT_ID/node-debug-base.$BRANCH_NAME:10.10.0 --build-arg=GITHUB_PAT=$$GITHUB_PAT fat-base/']
+secretEnv: ['GITHUB_PAT']
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: ['-c', 'docker build --target builder --build-arg=NODE_VERSION=10.10.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.10.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.x --build-arg=NPM_VERSION=6.4.1 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
     secretEnv: ['GITHUB_PAT']
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
@@ -19,7 +23,7 @@ steps:
   # node 8.11.4
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker build --target base --build-arg=NODE_VERSION=8.11.4 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:8.11.4 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:8.x --build-arg=NPM_VERSION=6.4.0 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
+    args: ['-c', 'docker build --target base --build-arg=NODE_VERSION=8.11.4 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:8.11.4 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:8.x --build-arg=NPM_VERSION=6.4.1 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
     secretEnv: ['GITHUB_PAT']
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
@@ -27,7 +31,7 @@ steps:
     secretEnv: ['GITHUB_PAT']
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker build --target builder --build-arg=NODE_VERSION=8.11.4 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:8.11.4 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:8.x --build-arg=NPM_VERSION=6.4.0 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
+    args: ['-c', 'docker build --target builder --build-arg=NODE_VERSION=8.11.4 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:8.11.4 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:8.x --build-arg=NPM_VERSION=6.4.1 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
     secretEnv: ['GITHUB_PAT']
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
@@ -38,6 +42,7 @@ steps:
     args: ['-c', 'docker run test:8.11.4']
 images: 
   - 'gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.10.0'
+  - 'gcr.io/$PROJECT_ID/node-fat-base.$BRANCH_NAME:10.10.0'
   - 'gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.10.0'
   - 'gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.x'
   - 'gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.x'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
     args: ['-c', 'docker build --build-arg=NODE_VERSION=10.10.0 --tag=gcr.io/$PROJECT_ID/node-fat-base.$BRANCH_NAME:10.10.0 --tag=gcr.io/$PROJECT_ID/node-debug-base.$BRANCH_NAME:10.10.0 --build-arg=GITHUB_PAT=$$GITHUB_PAT fat-base/']
-secretEnv: ['GITHUB_PAT']
+    secretEnv: ['GITHUB_PAT']
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
     args: ['-c', 'docker build --target builder --build-arg=NODE_VERSION=10.10.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.10.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.x --build-arg=NPM_VERSION=6.4.1 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,20 +1,20 @@
 steps:
-  # node 10.9.0
+  # node 10.10.0
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker build --target base --build-arg=NODE_VERSION=10.9.0 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.9.0 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.x --build-arg=NPM_VERSION=6.4.0 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
+    args: ['-c', 'docker build --target base --build-arg=NODE_VERSION=10.10.0 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.10.0 --tag=gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.x --build-arg=NPM_VERSION=6.4.0 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
     secretEnv: ['GITHUB_PAT']
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker build --target builder --build-arg=NODE_VERSION=10.9.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.9.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.x --build-arg=NPM_VERSION=6.4.0 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
+    args: ['-c', 'docker build --target builder --build-arg=NODE_VERSION=10.10.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.10.0 --tag=gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.x --build-arg=NPM_VERSION=6.4.0 --build-arg=YARN_VERSION=1.9.4 --build-arg=GITHUB_PAT=$$GITHUB_PAT .']
     secretEnv: ['GITHUB_PAT']
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker build --build-arg=NODE_VERSION=10.9.0 --build-arg=BRANCH_NAME=$BRANCH_NAME --tag=test:10.9.0 --build-arg=GITHUB_PAT=$$GITHUB_PAT test/']
+    args: ['-c', 'docker build --build-arg=NODE_VERSION=10.10.0 --build-arg=BRANCH_NAME=$BRANCH_NAME --tag=test:10.10.0 --build-arg=GITHUB_PAT=$$GITHUB_PAT test/']
     secretEnv: ['GITHUB_PAT']
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker run test:10.9.0']
+    args: ['-c', 'docker run test:10.10.0']
 
   # node 8.11.4
   - name: 'gcr.io/cloud-builders/docker'
@@ -37,8 +37,8 @@ steps:
     entrypoint: 'bash'
     args: ['-c', 'docker run test:8.11.4']
 images: 
-  - 'gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.9.0'
-  - 'gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.9.0'
+  - 'gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.10.0'
+  - 'gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.10.0'
   - 'gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:10.x'
   - 'gcr.io/$PROJECT_ID/node-builder.$BRANCH_NAME:10.x'
   - 'gcr.io/$PROJECT_ID/node-base.$BRANCH_NAME:8.11.4'

--- a/fat-base/Dockerfile
+++ b/fat-base/Dockerfile
@@ -1,6 +1,6 @@
-ARG NODE_VERSION=8.x
+ARG NODE_VERSION=10.x
 
-FROM gcr.io/connectedcars-staging/node-base.node-1010:$NODE_VERSION
+FROM gcr.io/connectedcars-staging/node-base.master:$NODE_VERSION
 
 USER root
 

--- a/fat-base/Dockerfile
+++ b/fat-base/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=8.x
 
-FROM gcr.io/connectedcars-staging/node-base.master:$NODE_VERSION
+FROM gcr.io/connectedcars-staging/node-base.node-1010:$NODE_VERSION
 
 USER root
 


### PR DESCRIPTION
Bump to node 10.10.0
Bump npm to 6.4.1
Make fatbase use node 10.10.0 (which has fixed segfault, has been tested)