### PR TITLE
Security update 2021-01-04

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,10 @@
 substitutions:
-  _NODE_VERSION_15: 15.4.0
-  _NODE_VERSION_14: 14.15.2
-  _NODE_VERSION_12: 12.20.0
-  _NODE_VERSION_10: 10.23.0
+  _NODE_VERSION_15: 15.5.1
+  _NODE_VERSION_14: 14.15.4
+  _NODE_VERSION_12: 12.20.1
+  _NODE_VERSION_10: 10.23.1
   _YARN_VERSION: 1.22.10
-  _NPM_VERSION: 6.14.9
+  _NPM_VERSION: 6.14.10
 steps:
   # copy build key to workspace
   - name: 'gcr.io/cloud-builders/gsutil'


### PR DESCRIPTION
## _(Update 4-Jan-2021)_ Security releases available

Updates are now available for v10,x, v12.x, v14.x and v15.x Node.js release lines for the following issues.

In addition to the vulnerabilities listed below, these releases also include an update to npm in order to resolve an issue that was reported against npm by security scanners even though it was not vulnerable.

### use-after-free in TLSWrap (High) (CVE-2020-8265)

Affected Node.js versions are vulnerable to a use-after-free bug in its TLS implementation 
when writing to a TLS enabled socket, node::StreamBase::Write calls node::TLSWrap::DoWrite
with a freshly allocated WriteWrap object as first argument. If the DoWrite method
does not return an error, this object is passed back to the caller as part of a
StreamWriteResult structure. This may be exploited to corrupt memory leading to a Denial of Service or potentially other exploits.

Impacts:
* All versions of the 15.x, 14.x, 12.x and 10.x releases lines

Thank you to Felix Wilhelm from Google Project Zero for reporting this vulnerability.

### HTTP Request Smuggling in nodejs (CVE-2020-8287)

Affected versions of Node.js allow two copies of a header field in a http request. For example, two Transfer-Encoding header fields. In this case Node.js identifies the first header field and ignores the second. This can lead to HTTP Request Smuggling (https://cwe.mitre.org/data/definitions/444.html).

Impacts:
* All versions of the 15.x, 14.x, 12.x and 10.x releases lines

Thank you to niubl who works at TSRC(Tencent Security Response Center) for reporting this vulnerability

### OpenSSL - EDIPARTYNAME NULL pointer de-reference (CVE-2020-1971)

This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in
https://www.openssl.org/news/secadv/20201208.txt

Impacts:
* All versions of the 14.x, 12.x and 10.x release lines
* Versions of the 15.x line before 15.5.0 which included an update to the latest OpenSSL.

## Downloads and release details

* [Node.js v10.23.1 (LTS)](https://nodejs.org/en/blog/release/v10.23.1/)
* [Node.js v12.20.1 (LTS)](https://nodejs.org/en/blog/release/v12.20.1/)
* [Node.js v14.15.4 (LTS)](https://nodejs.org/en/blog/release/v14.15.4/)
* [Node.js v15.5.1 (Current)](https://nodejs.org/en/blog/release/v15.5.1/)