### PR TITLE
Update cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,10 @@
 substitutions:
-  _NODE_VERSION_15: 15.8.0
-  _NODE_VERSION_14: 14.15.5
-  _NODE_VERSION_12: 12.20.2
-  _NODE_VERSION_10: 10.23.3
+  _NODE_VERSION_15: 15.10.0
+  _NODE_VERSION_14: 14.16.0
+  _NODE_VERSION_12: 12.21.0
+  _NODE_VERSION_10: 10.24.0
   _YARN_VERSION: 1.22.10
-  _NPM_VERSION: 7.5.4
+  _NPM_VERSION: 7.6.0
 steps:
   # copy build key to workspace
   - name: 'gcr.io/cloud-builders/gsutil'


### PR DESCRIPTION
# Summary                                                                       
                                                                                   
The Node.js project will release new versions of all supported release lines on or shortly after Tuesday, February 23th, 2021.
                                                                                   
* One Critical serverity issue                                                     
* One High serverity issue                                                         
* One Low serverity issue                                                          
                                                                                   
## Impact                                                                          
                                                                                   
The 15.x release line of Node.js is vulnerable to one critical severity issue, one high severity issue, and one low severity issue.
                                                                                   
The 14.x release line of Node.js is vulnerable to one critical severity issue, one high severity issue, and one low severity issue.
                                                                                   
The 12.x release line of Node.js is vulnerable to one critical severity issue, one high severity issue, and one low severity issue.
                                                                                   
The 10.x release line of Node.js is vulnerable to one critical severity issue, one high severity issue, and one low severity issue.
                                                                                   
## Release timing                                                              
Releases will be available at, or shortly after, Tuesday, February 23th, 2021.  
                                                                                   
## Contact and future updates                                                                                       
The current Node.js security policy can be found at https://nodejs.org/en/security/. Please follow the process outlined in https://github.com/nodejs/node/blob/master/SECURITY.md if you wish to report a vulnerability in Node.js.
                                                                                   
Subscribe to the low-volume announcement-only nodejs-sec mailing list at https://groups.google.com/forum/#!forum/nodejs-sec to stay up to date on security vulnerabilities and security-related releases of Node.js and the projects maintained in the nodejs GitHub organization.

## _(Update 23-Feb-2021)_ Security releases available

Updates are now available for v10.x, v12.x, v14.x and v15.x Node.js release lines for the following issues.

### HTTP2 'unknownProtocol' cause Denial of Service by resource exhaustion (Critical) (CVE-2021-22883)

Affected Node.js versions are vulnerable to denial of service attacks when too many connection attempts with an 'unknownProtocol' are established. This leads to a leak of file descriptors. If a file descriptor limit is configured on the system, then the server is unable to accept new connections and prevent the process also from opening, e.g. a file. If no file descriptor limit is configured, then this lead to an excessive memory usage and cause the system to run out of memory.

Impacts:
* All versions of the 15.x, 14.x, 12.x and 10.x releases lines

Thank you to OMICRON electronics for reporting this vulnerability.

### DNS rebinding in --inspect (CVE-2021-22884)

Affected Node.js versions are vulnerable to denial of service attacks when the whitelist includes “localhost6”. When “localhost6” is not present in /etc/hosts, it is just an ordinary domain that is resolved via DNS, i.e., over network. If the attacker controls the victim's DNS server or can spoof its responses, the DNS rebinding protection can be bypassed by using the “localhost6” domain. As long as the attacker uses the “localhost6” domain, they can still apply the attack described in CVE-2018-7160. 

Impacts:
* All versions of the 15.x, 14.x, 12.x and 10.x releases lines

Thank you to Vít Šesták for reporting this vulnerability

### OpenSSL - Integer overflow in CipherUpdate (CVE-2021-23840)

This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in
https://www.openssl.org/news/secadv/20210216.txt

Impacts:
* All versions of the 15.x, 14.x, 12.x and 10.x releases lines

## Downloads and release details

* [Node.js v10.24.0 (LTS)](https://nodejs.org/en/blog/release/v10.24.0/)
* [Node.js v12.21.0 (LTS)](https://nodejs.org/en/blog/release/v12.21.0/)
* [Node.js v14.16.0 (LTS)](https://nodejs.org/en/blog/release/v14.16.0/)
* [Node.js v15.10.0 (Current)](https://nodejs.org/en/blog/release/v15.10.0/)