### PR TITLE
Don't run shell resolve twice

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,11 +14,11 @@ steps:
     args: ['-c', './build-all.sh']
     env: ['COMMIT_SHA=${COMMIT_SHA}','BRANCH_NAME=${BRANCH_NAME}','PROJECT_ID=${PROJECT_ID}', 'PUSH=y']
     secretEnv: ['NPM_TOKEN']
-    timeout: 7200s
+    timeout: 14400s
 secrets:
 - kmsKeyName: projects/connectedcars-staging/locations/global/keyRings/cloudbuilder/cryptoKeys/connectedcars-builder
   secretEnv:
     NPM_TOKEN: CiQAg7wCPRLVNzCKg+NMXRanl3WmpnMKu2t+ufAPuPXLEDgheDISUQBefMgeLbcPimMQUK7wQyKw0A+DYrzXBA2vdBHvs/9EcChdsQXsVeC3DMBgufqUP73TWL6aH3a94zyC1zuo1JzyBL+dsZIEl47l3eYW6nFK3A==
-timeout: 10800s
+timeout: 14460s
 options:
   machineType: 'E2_HIGHCPU_32'

--- a/files/opt/connectedcars/bin/npm
+++ b/files/opt/connectedcars/bin/npm
@@ -4,4 +4,4 @@ if [ ! -n "$NPM_TOKEN" ]; then
     export NPM_TOKEN=""
 fi
 
-exec /usr/local/bin/npm $@
+exec /usr/local/bin/npm "$@"

--- a/files/opt/connectedcars/bin/npx
+++ b/files/opt/connectedcars/bin/npx
@@ -4,4 +4,4 @@ if [ ! -n "$NPM_TOKEN" ]; then
     export NPM_TOKEN=""
 fi
 
-exec /usr/local/bin/npx $@
+exec /usr/local/bin/npx "$@"


### PR DESCRIPTION
This fixes an issue where you try to escape fx. *

``` bash
npm stuff -- -u "*"
```

Will run the command without "" and use shell globbing, this is fixed by wrapping "$@"