### PR TITLE
Add helper for working with docker build secrets and do some minor cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,17 @@ ARG TARGETARCH
 # Make sure we run latest ubuntu and install some basic packages
 RUN apt-get update -qq && \
 	apt-get dist-upgrade -qq -y --no-install-recommends && \
-	apt-get install -qq -y --no-install-recommends ca-certificates && \
+	apt-get install -qq -y --no-install-recommends ca-certificates locales && \
 	rm -rf /var/lib/apt/lists/*
+
+# Set UTF8 locals
+RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8'
+ENV LANGUAGE='en_US:en'
+ENV LC_ALL='en_US.UTF-8'
 
 # Disable color output and be less verbose
 ENV NO_COLOR=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN ln -s /usr/local/bin/node /usr/local/bin/nodejs
 COPY --from=downloader /opt/yarn-v$YARN_VERSION /usr/local
 
 # Disable npm color output and be less verbose
-RUN npm config set color false
+RUN npm config set color false --global
 
 # Read NPM token from environment variable
 RUN npm config set '//registry.npmjs.org/:_authToken' '${NPM_TOKEN}' --global

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ echo "<encypted key>" | base64 -D | gcloud kms decrypt --plaintext-file=- --ciph
 ``` bash
 export NPM_TOKEN=`cat ~/.npmrc|grep _authToken|cut -d '=' -f 2`
 # Only build specific node version on arm64
-PROJECT_ID=connectedcars-staging NODE_VERSIONS="16.16.0" BUILD_PLATFORMS="linux/arm64" COMMIT_SHA=ABCD1234 BRANCH_NAME=`git symbolic-ref --short -q HEAD` ./build-all.sh
+PROJECT_ID=connectedcars-staging NODE_VERSIONS="20.8.1" BUILD_PLATFORMS="linux/arm64" COMMIT_SHA=ABCD1234 BRANCH_NAME=`git symbolic-ref --short -q HEAD` ./build-all.sh
 ```
 
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -66,7 +66,7 @@ for NODE_VERSION in $NODE_VERSIONS; do
         echo "Building test image with buildx for node $NODE_VERSION for $PLATFORM"
         docker images
         docker buildx ls
-        docker buildx build --instance=default --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
+        docker buildx build --builder=default --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
         echo "Running test image for node $NODE_VERSION for $PLATFORM"
         docker run --platform="${PLATFORM}" "test:${NODE_VERSION}"
     done

--- a/build-all.sh
+++ b/build-all.sh
@@ -64,6 +64,7 @@ for NODE_VERSION in $NODE_VERSIONS; do
         docker run --platform="${PLATFORM}" "test:${NODE_VERSION}"
 
         echo "Building test image with buildx for node $NODE_VERSION for $PLATFORM"
+        docker images
         docker buildx build --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
         echo "Running test image for node $NODE_VERSION for $PLATFORM"
         docker run --platform="${PLATFORM}" "test:${NODE_VERSION}"

--- a/build-all.sh
+++ b/build-all.sh
@@ -64,10 +64,12 @@ for NODE_VERSION in $NODE_VERSIONS; do
         docker run --platform="${PLATFORM}" "test:${NODE_VERSION}"
 
         echo "Building test image with buildx for node $NODE_VERSION for $PLATFORM"
-        docker images
-        docker buildx ls
-        docker context ls
-        docker --context=default buildx build --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
+        # For some reason the multi arch builder does not have access to the 
+        # local images on google cloud builds version of docker so we need 
+        # to use default to get this working. Also docker for mac no creates
+        # a desktop-linux context where you can't set builder so we need to
+        # also set the context for this to work there.
+        docker --context default buildx build --builder default --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
         echo "Running test image for node $NODE_VERSION for $PLATFORM"
         docker run --platform="${PLATFORM}" "test:${NODE_VERSION}"
     done

--- a/build-all.sh
+++ b/build-all.sh
@@ -46,8 +46,7 @@ for NODE_VERSION in $NODE_VERSIONS; do
     NODE_MAJOR_VERSION=$(echo "$NODE_VERSION" | cut -d. -f1)
 
     DOCKER_NODE_BUILD_ARGS="--build-arg=NODE_VERSION=${NODE_VERSION} --build-arg=NPM_VERSION=${NPM_VERSION} --build-arg=YARN_VERSION=${YARN_VERSION}"
-    DOCKER_TEST_BUILD_ARGS="--build-arg=NODE_VERSION=${NODE_VERSION} --build-arg=NPM_TOKEN=${NPM_TOKEN} --build-arg=BRANCH_NAME=${BRANCH_NAME}"
-
+    
     # Build image cache for all platforms so it's ready
     echo "Building node $NODE_VERSION images for $BUILD_PLATFORMS";
     docker buildx build --platform="${DOCKER_PLATFORMS}" --progress=plain ${DOCKER_NODE_BUILD_ARGS} .
@@ -60,12 +59,12 @@ for NODE_VERSION in $NODE_VERSIONS; do
         docker buildx build --platform="${PLATFORM}" --progress=plain --target=fat-base --load --tag="gcr.io/${PROJECT_ID}/node-fat-base.${BRANCH_NAME}:${NODE_VERSION}" ${DOCKER_NODE_BUILD_ARGS} .
 
         echo "Building test image with old docker build for node $NODE_VERSION for $PLATFORM"
-        DOCKER_BUILDKIT=0 docker build --platform="${PLATFORM}" --progress=plain --tag="test:${NODE_VERSION}" ${DOCKER_TEST_BUILD_ARGS} test/
+        DOCKER_BUILDKIT=0 docker build --platform="${PLATFORM}" --tag="test:${NODE_VERSION}" --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" --build-arg=NPM_TOKEN="${NPM_TOKEN}" -f test/Dockerfile.old test/
         echo "Running test image for node $NODE_VERSION for $PLATFORM"
         docker run --platform="${PLATFORM}" "test:${NODE_VERSION}"
 
         echo "Building test image with buildx for node $NODE_VERSION for $PLATFORM"
-        docker buildx build --platform="${PLATFORM}" --progress=plain --builder default --load --tag="test:${NODE_VERSION}" ${DOCKER_TEST_BUILD_ARGS} test/
+        docker buildx build --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
         echo "Running test image for node $NODE_VERSION for $PLATFORM"
         docker run --platform="${PLATFORM}" "test:${NODE_VERSION}"
     done

--- a/build-all.sh
+++ b/build-all.sh
@@ -66,7 +66,8 @@ for NODE_VERSION in $NODE_VERSIONS; do
         echo "Building test image with buildx for node $NODE_VERSION for $PLATFORM"
         docker images
         docker buildx ls
-        docker buildx build --builder=default --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
+        docker context ls
+        docker --context=default buildx build --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
         echo "Running test image for node $NODE_VERSION for $PLATFORM"
         docker run --platform="${PLATFORM}" "test:${NODE_VERSION}"
     done

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 NODE_STABLE="18"
 NODE_VERSIONS=${NODE_VERSIONS:="20.8.1 18.18.2"}
@@ -65,7 +65,8 @@ for NODE_VERSION in $NODE_VERSIONS; do
 
         echo "Building test image with buildx for node $NODE_VERSION for $PLATFORM"
         docker images
-        docker buildx build --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
+        docker buildx ls
+        docker buildx build --instance=default --platform="${PLATFORM}" --progress=plain --load --tag="test:${NODE_VERSION}" --secret id=NPM_TOKEN --build-arg=NODE_VERSION="${NODE_VERSION}" --build-arg=BRANCH_NAME="${BRANCH_NAME}" test/
         echo "Running test image for node $NODE_VERSION for $PLATFORM"
         docker run --platform="${PLATFORM}" "test:${NODE_VERSION}"
     done

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,13 +1,6 @@
 steps:
-  # Register qemu targets with linux
-  - name: gcr.io/cloud-builders/docker
-    args: ['run', '--rm', '--privileged', 'multiarch/qemu-user-static', '--reset', '-p', 'yes']
-  # Create a new builder that supports multi arch and use this as instead
-  - name: gcr.io/cloud-builders/docker
-    args: ['buildx', 'create', '--name', 'multi-arch-builder', '--use']
-  # List build targets
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['buildx', 'inspect', '--bootstrap']
+  # Setup docker with buildkit and other fixes
+  - name: 'gcr.io/connectedcars-staging/cloud-build-init.master'
   # Build all images
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'

--- a/files/opt/connectedcars/bin/npm
+++ b/files/opt/connectedcars/bin/npm
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! -n "$NPM_TOKEN" ]; then
+if [ -z "$NPM_TOKEN" ]; then
     export NPM_TOKEN=""
 fi
 

--- a/files/opt/connectedcars/bin/npx
+++ b/files/opt/connectedcars/bin/npx
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! -n "$NPM_TOKEN" ]; then
+if [ -z "$NPM_TOKEN" ]; then
     export NPM_TOKEN=""
 fi
 

--- a/files/opt/connectedcars/bin/secrets2env
+++ b/files/opt/connectedcars/bin/secrets2env
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ $# -eq 0 ]; then
-    echo "secret2env command"
+    echo "secrets2env command"
     exit 1
 fi
 

--- a/files/opt/connectedcars/bin/secrets2env
+++ b/files/opt/connectedcars/bin/secrets2env
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ $# -eq 0 ]; then
+    echo "secret2env command"
+    exit 1
+fi
+
+if [ -d /run/secrets ]; then
+    for v in /run/secrets/*; do
+        export "$(basename "$v")"="$(cat "$v")"; 
+    done
+fi
+
+exec "$@"

--- a/test/Dockerfile.old
+++ b/test/Dockerfile.old
@@ -3,6 +3,8 @@ ARG BRANCH_NAME=master
 
 FROM gcr.io/connectedcars-staging/node-builder.$BRANCH_NAME:$NODE_VERSION as builder
 
+ARG NPM_TOKEN=""
+
 WORKDIR /app
 
 USER builder
@@ -31,9 +33,7 @@ RUN uname -a
 
 RUN export | sed 's/\(NPM_TOKEN=....\).*\(....\)/\1___\2/g'
 
-RUN --mount=type=ssh \
-    --mount=type=secret,id=NPM_TOKEN,uid=1000 \
-    secrets2env npm install
+RUN npm install
 
 RUN npm test
 


### PR DESCRIPTION
* Add secrets2env
* Update test builds to support old and new secrets parsing
* Add locales and default to en_US.UTF8
* Remove --builder default from test as it seems to not work on newer docker versions 